### PR TITLE
Work in stopwatch mode when no arguments are given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+snore.o
+snore

--- a/snore.c
+++ b/snore.c
@@ -113,16 +113,24 @@ main(int argc, char *argv[]) {
 			die("%s: wrong time\n", argv[i]);
 		endtm += tm;
 	}
+
 	if(!endtm)
-		endtm = symbols[LENGTH(symbols) - 1].mult;
-	for(tm = 0; tm < endtm; tm += DELTA) {
-		time_print(tm); /* ascending */
-		printf(" | ");
-		time_print(endtm - tm); /* descending */
-		fflush(stdout);
-		sleepu(TICK);
-		printf("%s", CLEAR);
-	}
+		for (tm = 0;; tm += DELTA) {
+			time_print(tm);
+			fflush(stdout);
+			sleepu(TICK);
+			printf("%s", CLEAR);
+		}
+	else
+		for(tm = 0; tm < endtm; tm += DELTA) {
+			time_print(tm); /* ascending */
+			printf(" | ");
+			time_print(endtm - tm); /* descending */
+			fflush(stdout);
+			sleepu(TICK);
+			printf("%s", CLEAR);
+		}
+
 	printf("\a%s elapsed\n", argv[1]);
 	return 0;
 }

--- a/snore.c
+++ b/snore.c
@@ -44,14 +44,14 @@ die(const char *errstr, ...) {
 
 int
 sleepu(double usec) {
-        struct timespec req, rem;
-        int r;
+	struct timespec req, rem;
+	int r;
 
-        req.tv_sec = 0;
-        req.tv_nsec = usec * 1000;
-        while((r = nanosleep(&req, &rem)) == -1 && errno == EINTR)
-                req = rem;
-        return r;
+	req.tv_sec = 0;
+	req.tv_nsec = usec * 1000;
+	while((r = nanosleep(&req, &rem)) == -1 && errno == EINTR)
+		req = rem;
+	return r;
 }
 
 double


### PR DESCRIPTION
Here I suggest to change the default behavior of `snore` when no arguments are given. Instead of sleeping for 24h, just act as a stopwatch, to be stopped with `^C`.

I didn't update the manpage, as I'd like to have an opinion on this change before any further work.