### PR TITLE
2 tuned tick sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 dist: clean
 	@echo creating dist tarball
 	@mkdir -p ${APPNAME}-${VERSION}
-	@cp -R LICENSE Makefile README config.mk \
+	@cp -R LICENSE Makefile README.md config.mk \
 		${APPNAME}.1 ${SRC} ${APPNAME}-${VERSION}
 	@tar -cf ${APPNAME}-${VERSION}.tar ${APPNAME}-${VERSION}
 	@gzip ${APPNAME}-${VERSION}.tar

--- a/config.mk
+++ b/config.mk
@@ -12,7 +12,7 @@ INCS =
 LIBS =
 
 # flags
-CPPFLAGS = -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=2 -DVERSION=\"${VERSION}\"
+CPPFLAGS = -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=2 -DVERSION=\"${VERSION}\" $(EXTRA_CPPFLAGS)
 #CFLAGS   = -g -std=c99 -pedantic -Wall -O0 ${INCS} ${CPPFLAGS}
 CFLAGS   = -std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os ${INCS} ${CPPFLAGS}
 LDFLAGS  = -s ${LIBS}


### PR DESCRIPTION
1. applied snore-Makefile-master.diff     fix  in Makefile for README.md file.
2. change to config.mk that enables:
          export EXTRA_CPPFLAGS=-DDISABLE_BUFFERING=1; make clean ; make
to produce unbuffered i/o to stdout..
3.  The function. zzz_loop(struct timespec start_tsp, double stop_tm, double end_tm, double tick)
    is called once the TICK size of 25000000 and the fineal 250 msecs (or less) have a TICK size of 100.
4. The simplifed status reporting is changed to:
.        printf("%.3fs elapsed | %.3fs remaining ", current_tm, end_tm - current_tm);   