### PR TITLE
The  nanosleep tick size now varies from 250 usec to 0.0001 usec.

### DIFF
--- a/snore.c
+++ b/snore.c
@@ -7,8 +7,9 @@
 #include <string.h>
 #include <time.h>
 
-#define TICK        0250000
-#define DELTA       ((double)TICK / 1000000)
+#define BILLION     1000000000.0
+#define TICK        250000
+#define TICKL       100
 #define CLEAR	    "\33[2K\r"
 #define LENGTH(X)   (sizeof X / sizeof X[0])
 #define ISCHR(c)    (c >= 'a' && c <= 'z')
@@ -103,7 +104,10 @@ time_print(double tm) {
 
 int
 main(int argc, char *argv[]) {
+	struct timespec start, current;
+	clock_gettime(CLOCK_REALTIME, &start);
 	double endtm = 0, tm;
+	double tick,tickslope;
 	int i;
 
 	if(argc == 2 && !strcmp("-v", argv[1]))
@@ -121,13 +125,19 @@ main(int argc, char *argv[]) {
 				die("%s: time too large\n", argv[0]);
 		}
 	}
-	for(tm = 0; tm < endtm; tm += DELTA) {
+	tickslope=(TICKL-TICK)/endtm;
+	tick=TICK;
+	for(tm = 0; tm < endtm;    ) {
 		time_print(tm); /* ascending */
 		printf(" | ");
 		time_print(endtm - tm); /* descending */
 		fflush(stdout);
-		sleepu(TICK);
+		sleepu(tick);
 		printf(CLEAR);
+		clock_gettime(CLOCK_REALTIME, &current);
+		tm = (current.tv_sec - start.tv_sec) +
+			(current.tv_nsec - start.tv_nsec) / BILLION;
+		tick=TICK+tickslope*tm;
 	}
 	printf("\a%s elapsed\n", argv[1]);
 	return 0;


### PR DESCRIPTION
The tick size is no longer a constant 250 usec.  At the end of the program run the deltas are so small that the elapsed time and the specified time are nearly identical.