### PR TITLE
General correctness improvements

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -9,12 +9,12 @@ MANPREFIX = ${PREFIX}/share/man
 
 # includes and libs
 INCS =
-LIBS =
+LIBS = -lm
 
 # flags
 CPPFLAGS = -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L -DVERSION=\"${VERSION}\"
 #CFLAGS   = -g -std=c99 -pedantic -Wall -O0 ${INCS} ${CPPFLAGS}
-CFLAGS   = -std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os ${INCS} ${CPPFLAGS}
+CFLAGS   = -std=c99 -pedantic -Wall -Wextra -Werror -Wno-deprecated-declarations -Os ${INCS} ${CPPFLAGS}
 LDFLAGS  = ${LIBS}
 
 # Solaris


### PR DESCRIPTION
* Replace potentially-unsafe use of `strrchr` with a format string
  generated via `snprintf`
* Make `symbol_t::precision` `unsigned` to prevent potentially corrupt
  generated format strings.
* Replace possibly overflowing double-to-int cast with `trunc()`
* Change the `endtm` range check to exclude NaN
* Improve error message if `endtm` range check fails
* Enable `-Wextra` and `-Werror`, and fix the warning caused by
  `j < LENGTH(symbols)`.