### PR TITLE
time_print: Round components down

### DIFF
--- a/snore.c
+++ b/snore.c
@@ -87,14 +87,14 @@ time_to_sec(char *s) {
 
 void
 time_print(double tm) {
-	double piece;
-	int i;
+	int days = (int)(tm/(24*3600));
+	tm -= days * (24*3600);
+	int hours = (int)(tm/3600);
+	tm -= hours * 3600;
+	int minutes = (int)(tm/60);
+	tm -= minutes * 60;
 
-	for(i = LENGTH(symbols) - 1; i >= 0; --i) {
-		piece = tm / symbols[i].mult;
-		printf("%.*f%c%s", symbols[i].precision, piece, symbols[i].sym, i ? " " : "");
-		tm -= (int)piece * symbols[i].mult;
-	}
+	printf("%dd %dh %dm %.3fs", days, hours, minutes, tm);
 }
 
 int


### PR DESCRIPTION
When I run `snore` without arguments, I get output like
```
0d 0h 0m 1.752s | 1d 24h 60m 58.248s
```
Is this intentional? I would have expected something like
```
0d 0h 0m 1.752s | 0d 23h 59m 58.248s
```
This PR does that.